### PR TITLE
Remove find hypotenuse repl from Getting Strings From Users chapter

### DIFF
--- a/getting-strings-from-users.md
+++ b/getting-strings-from-users.md
@@ -44,4 +44,3 @@ Test your skills:
 
 <iframe frameborder="0" width="100%" height="600px" src="https://repl.it/student_embed/assignment/3075907/f9998ca0e45feb87972cfb616aa698a5"></iframe>
 
-<iframe frameborder="0" width="100%" height="600px" src="https://repl.it/student_embed/assignment/3075914/13838173da964e3be6370c9195064b13"></iframe>


### PR DESCRIPTION
There's an almost duplicate repl for finding the hypotenuse. One is in "Getting Strings From Users" chapter and the other one is in the "Float" chapter. Going chronologically, the students won't be able to solve it in "Getting Strings from Users" since they wouldn't know how to convert string to floats.