### PR TITLE
Add String#include?

### DIFF
--- a/string.md
+++ b/string.md
@@ -263,6 +263,12 @@ a.at(0) # => "H"
 a.at(-1) # => "!"
 ```
 
+### include?
+
+`include?` takes a String argument and returns `true` or `false` if the argument exists in the String that `include?` is called on. 
+
+<iframe height="600px" width="100%" src="https://repl.it/@raghubetina/stringinclude?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+
 ## More on adding strings together
 
 We spend a lot of time composing strings of output for our users, so let's see a few more examples. Try this:

--- a/the-one-reference.md
+++ b/the-one-reference.md
@@ -767,6 +767,30 @@ Returns
 
 [Full explanation](https://chapters.firstdraft.com/chapters/757#split)
 
+### .include?
+
+`String#include?(String) ⇒ Boolean`
+
+Returns a [_boolean_](#conditionals)(`true` or `false`) based on whether the string argument is inside the string the method is being called on.
+
+```ruby
+"Happy".include?("H")
+```
+
+Returns
+
+`true`
+
+```ruby
+"Happy".include?("Z")
+```
+
+Returns
+
+`false`
+
+[Full explanation](https://chapters.firstdraft.com/chapters/757#include?)
+
 ## Integer
 
 whole numbers


### PR DESCRIPTION
Resolves #34 

Since `exclude?` is Rails, I've _excluded_ it from the chapter 😉 

This adds:
- `String#include?` to the String chapter
- `String#include?` to the one-reference chapter

The codacy errors are for ending the headings with `?`, which is kind of unavoidable. 