### PR TITLE
Add note about timestamp columns

### DIFF
--- a/photogram-final.md
+++ b/photogram-final.md
@@ -12,6 +12,8 @@ We domain modeled this application in first two weeks of class, and used the sam
 
 ![](/assets/photogram-final-erd.png)
 
+_All tables should have the usual `created_at` and `updated_at` columns_
+
 If you add these columns _exactly_, then you can run the `rails sample_data` Rake task to add dummy data to your database tables like with the homeworks.
 
 You can use the `model` generator to add your tables, or you can use [the `draft_generators`](https://chapters.firstdraft.com/chapters/773) to add the tables _and_ give yourself a big head start on routes, controllers, actions, and view templates.


### PR DESCRIPTION
A student purposefully removed `t.timestamps` from the migrations b/c they weren't in the ERD, so I thought a small note might be helpful so it doesn't happen again.