### PR TITLE
Fix ApplicationRecord typo in image-uploads

### DIFF
--- a/image-uploads.md
+++ b/image-uploads.md
@@ -50,7 +50,7 @@ In your case, change `Avatar` to match whatever you are trying to upload / the c
 
 ### Mount the uploader in the model
 
-In the relevant model,
+In the relevant model add `mount_uploader :avatar, AvatarUploader`.
 
 ```ruby
 # app/models/user.rb

--- a/image-uploads.md
+++ b/image-uploads.md
@@ -54,7 +54,7 @@ In the relevant model,
 
 ```ruby
 # app/models/user.rb
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   mount_uploader :avatar, AvatarUploader
 end
 ```


### PR DESCRIPTION
Three separate students reported to me that they were confused that the chapter example model inherited from `ActiveRecord::Base` instead of `ApplicationRecord`. This caused them to add a nested class instead of modifying the model class.

```rb
class User < ApplicationRecord
  class User < ActiveRecord::Base
    mount_uploader :avatar, AvatarUploader
  end
end
```

This PR changes the inherited model to be `ApplicationRecord`.